### PR TITLE
add get_attributes method to trackmanager

### DIFF
--- a/3d_detection_and_tracking/examples/kitti_tracking.cpp
+++ b/3d_detection_and_tracking/examples/kitti_tracking.cpp
@@ -39,6 +39,12 @@ int main()
 
     track_manager.predict_tracks(frame_count, ekf);
     association.associate_and_update(track_manager, meas_list, ekf);
+    std::map<uint, Attributes> attributes_list = track_manager.get_attributes();
+    for(auto& attr_pair : attributes_list)
+    {
+      std::cout << "attr key : " << attr_pair.first << std::endl; 
+      std::cout << "attr val : " << attr_pair.second.height << std::endl;
+    }
     std::map<uint, Track> track_list = track_manager.get_track_list();
     for(auto& track_pair : track_list)
     {

--- a/3d_detection_and_tracking/examples/kitti_tracking.cpp
+++ b/3d_detection_and_tracking/examples/kitti_tracking.cpp
@@ -45,20 +45,20 @@ int main()
       std::cout << "attr key : " << attr_pair.first << std::endl; 
       std::cout << "attr val : " << attr_pair.second.height << std::endl;
     }
-    std::map<uint, Track> track_list = track_manager.get_track_list();
-    for(auto& track_pair : track_list)
-    {
-      if (track_pair.second.get_state() == 2)
-      {
-        viewer.add_3d_bbox(track_pair.first, track_pair.second.get_attributes());
-        viewer.draw(
-        show_bbox_3D, 
-        showing_head, 
-        showing_id,
-        showing_topview);
-      }
-    }
-    viewer.show_result();
+    // std::map<uint, Track> track_list = track_manager.get_track_list();
+    // for(auto& track_pair : track_list)
+    // {
+    //   if (track_pair.second.get_state() == 2)
+    //   {
+    //     viewer.add_3d_bbox(track_pair.first, track_pair.second.get_attributes());
+    //     viewer.draw(
+    //     show_bbox_3D, 
+    //     showing_head, 
+    //     showing_id,
+    //     showing_topview);
+    //   }
+    // }
+    //viewer.show_result();
   }
   return 0;
 }

--- a/3d_detection_and_tracking/examples/real_time_kitti_tracking.cpp
+++ b/3d_detection_and_tracking/examples/real_time_kitti_tracking.cpp
@@ -101,25 +101,26 @@ int main()
       association.associate_and_update(track_manager, meas_list, ekf);
     }
 
-    std::map<uint, Attributes> attributes_list = std::move(track_manager.get_attributes());
+    std::map<uint, Attributes> attributes_list = track_manager.get_attributes();
     for(auto& attr_pair : attributes_list)
     {
       std::cout << "attr key : " << attr_pair.first << std::endl; 
     }
-    std::map<uint, Track> track_list = track_manager.get_track_list();
-    for (auto& track_pair : track_list)
-    {
-      if (track_pair.second.get_state() == 2)
-      {
-        viewer.add_3d_bbox(track_pair.first, track_pair.second.get_attributes());
-        viewer.draw(
-        show_bbox_3D, 
-        showing_head, 
-        showing_id,
-        showing_topview);
-      }
-    }
-    viewer.show_result();
+    
+    //std::map<uint, Track> track_list = track_manager.get_track_list();
+    // for (auto& track_pair : track_list)
+    // {
+    //   if (track_pair.second.get_state() == 2)
+    //   {
+    //     viewer.add_3d_bbox(track_pair.first, track_pair.second.get_attributes());
+    //     viewer.draw(
+    //     show_bbox_3D, 
+    //     showing_head, 
+    //     showing_id,
+    //     showing_topview);
+    //   }
+    // }
+    //viewer.show_result();
   }
   return 0;
 }

--- a/3d_detection_and_tracking/examples/real_time_kitti_tracking.cpp
+++ b/3d_detection_and_tracking/examples/real_time_kitti_tracking.cpp
@@ -41,7 +41,6 @@ int read_pipe()
     str.push_back(char(x));
   }
   std::cout << "str : " << str << std::endl;
-  std::cout << "str len : " << str.size() << std::endl;
   if (!isdigit(str[0]))
   {
     return -1;
@@ -102,6 +101,11 @@ int main()
       association.associate_and_update(track_manager, meas_list, ekf);
     }
 
+    std::map<uint, Attributes> attributes_list = std::move(track_manager.get_attributes());
+    for(auto& attr_pair : attributes_list)
+    {
+      std::cout << "attr key : " << attr_pair.first << std::endl; 
+    }
     std::map<uint, Track> track_list = track_manager.get_track_list();
     for (auto& track_pair : track_list)
     {

--- a/3d_detection_and_tracking/modules/object_tracking/include/object_tracking/Tracker.h
+++ b/3d_detection_and_tracking/modules/object_tracking/include/object_tracking/Tracker.h
@@ -21,9 +21,6 @@ public:
   Track(const Measurement& meas, uint id);
   virtual ~Track();
 
-  void update_attributes(const Measurement& meas);
-  void update_location();
-
   const Eigen::VectorXd& get_x() const;
   const Eigen::MatrixXd& get_P() const;
   double get_t() const;
@@ -39,8 +36,6 @@ public:
 
   void print() const;
 
-  const Attributes& get_attributes() const;
-
 private:
   uint id_;
   double t_;
@@ -53,7 +48,6 @@ private:
   double score_;
   uint state_;  // 0 : init, 1 : tentative, 2 : confirmed
 
-  Attributes attributes_;
 };
 
 class TrackManager
@@ -62,9 +56,9 @@ public:
   TrackManager();
   virtual ~TrackManager();
   void add_new_track(const Measurement& meas);
-
+  void delete_track(uint id);
   const std::map<uint, Track>& get_track_list() const;
-  std::map<uint, Attributes> get_attributes();
+  const std::map<uint, Attributes>& get_attributes() const;
 
   void manage_tracks(
     std::vector<uint> unassigned_track_ids,
@@ -75,9 +69,14 @@ public:
 
   void print();
 private:
+
+  void update_location(uint id);
+  void update_attributes(uint id, const Measurement& meas);
+
   uint current_num_tracks_;
   uint last_id_;
   std::map<uint, Track> track_list_;
+  std::map<uint, Attributes> attributes_list_;
 };
 
 #endif  // TRACKER_H_

--- a/3d_detection_and_tracking/modules/object_tracking/include/object_tracking/Tracker.h
+++ b/3d_detection_and_tracking/modules/object_tracking/include/object_tracking/Tracker.h
@@ -64,6 +64,7 @@ public:
   void add_new_track(const Measurement& meas);
 
   const std::map<uint, Track>& get_track_list() const;
+  std::map<uint, Attributes> get_attributes();
 
   void manage_tracks(
     std::vector<uint> unassigned_track_ids,

--- a/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/EKF.cpp
+++ b/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/EKF.cpp
@@ -33,7 +33,6 @@ void EKF::predict(uint frame_count, Track& track)
   track.set_x(x);
   track.set_P(P);
   track.set_t(cur_t);
-  track.update_location();
 }
 
 void EKF::update(Track& track, const Measurement& meas)
@@ -53,8 +52,6 @@ void EKF::update(Track& track, const Measurement& meas)
 
   track.set_x(x);
   track.set_P(P);
-  track.update_location();
-  track.update_attributes(meas);
 }
 
 Eigen::VectorXd EKF::get_y(const Track& track, const Measurement& meas) const

--- a/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/Tracker.cpp
+++ b/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/Tracker.cpp
@@ -27,7 +27,6 @@ Track::Track(const Measurement& meas, uint id)
   P_(5, 5) = sigma_p66 * sigma_p66;
 
   t_ = meas.get_t();
-  attributes_ = meas.get_attributes();
   state_ = 0;
   score_ = 1.0 / 6.0;
 }
@@ -75,31 +74,6 @@ void Track::set_t(double t)
   t_ = t;
 }
 
-const Attributes& Track::get_attributes() const
-{
-  return attributes_;
-}
-
-void Track::update_location()
-{
-  Eigen::VectorXd pos_veh = Eigen::VectorXd::Ones(4);
-  pos_veh.block<3, 1>(0, 0) = x_.block<3, 1>(0, 0);
-  Eigen::VectorXd pos_cam = veh_to_cam_ * pos_veh;
-
-  attributes_.loc_x = pos_cam(0, 0);
-  attributes_.loc_y = pos_cam(1, 0);
-  attributes_.loc_z = pos_cam(2, 0);
-}
-
-void Track::update_attributes(const Measurement& meas)
-{
-  Attributes meas_attributes = meas.get_attributes();
-  attributes_.height = 0.9 * attributes_.height + 0.1 * meas_attributes.height;
-  attributes_.width = 0.9 * attributes_.width + 0.1 * meas_attributes.width;
-  attributes_.length = 0.9 * attributes_.length + 0.1 * meas_attributes.length;
-  attributes_.rot_y = meas_attributes.rot_y;
-}
-
 void Track::set_x(const Eigen::VectorXd& x)
 {
   x_ = x;
@@ -117,15 +91,11 @@ void Track::print() const
   std::cout << "t_ = " << std::endl << t_ << std::endl;
   std::cout << "x_ = " << std::endl << x_ << std::endl;
   std::cout << "P_ = " << std::endl << P_ << std::endl;
-  std::cout << "width_ = " << std::endl << attributes_.width << std::endl;
-  std::cout << "height_ = " << std::endl << attributes_.height << std::endl;
-  std::cout << "length_ = " << std::endl << attributes_.length << std::endl;
-  std::cout << "yaw_ = " << std::endl << attributes_.rot_y << std::endl;
 }
 
 // TrackManager ---------------------------------------------------------
 
-TrackManager::TrackManager() 
+TrackManager::TrackManager()
 {
   last_id_ = 0;
   current_num_tracks_ = 0;
@@ -135,8 +105,17 @@ TrackManager::~TrackManager() {}
 void TrackManager::add_new_track(const Measurement& meas)
 {
   Track track(meas, ++last_id_);
+  Attributes attributes = meas.get_attributes();
   track_list_.insert({track.get_id(), track});
+  attributes_list_.insert({track.get_id(), attributes});
   ++current_num_tracks_;
+}
+
+void TrackManager::delete_track(uint id)
+{
+  track_list_.erase(id);
+  attributes_list_.erase(id);
+  --current_num_tracks_;
 }
 
 const std::map<uint, Track>& TrackManager::get_track_list() const
@@ -144,14 +123,9 @@ const std::map<uint, Track>& TrackManager::get_track_list() const
   return track_list_;
 }
 
-std::map<uint, Attributes> TrackManager::get_attributes()
+const std::map<uint, Attributes>& TrackManager::get_attributes() const
 {
-  std::map<uint, Attributes> ret;
-  for(const auto& track_pair : track_list_)
-  {
-    ret[track_pair.first] = track_pair.second.get_attributes();
-  }
-  return ret;
+  return attributes_list_;
 }
 
 void TrackManager::manage_tracks(
@@ -186,7 +160,7 @@ void TrackManager::manage_tracks(
 
   for (uint id : track_id_to_delete)
   {
-    track_list_.erase(id);
+    delete_track(id);
   }
 
   for (uint index : unassigned_meas_indexes)
@@ -195,11 +169,32 @@ void TrackManager::manage_tracks(
   }
 }
 
+void TrackManager::update_location(uint id)
+{
+  Eigen::VectorXd location = track_list_.at(id).get_x();
+  attributes_list_.at(id).loc_x = location(0);
+  attributes_list_.at(id).loc_y = location(1);
+  attributes_list_.at(id).loc_z = location(2);
+}
+
+void TrackManager::update_attributes(uint id, const Measurement& meas)
+{
+  Attributes meas_attributes = meas.get_attributes();
+  attributes_list_.at(id).height =
+    0.9 * attributes_list_.at(id).height + 0.1 * meas_attributes.height;
+  attributes_list_.at(id).width =
+    0.9 * attributes_list_.at(id).width + 0.1 * meas_attributes.width;
+  attributes_list_.at(id).length =
+    0.9 * attributes_list_.at(id).length + 0.1 * meas_attributes.length;
+  attributes_list_.at(id).rot_y = meas_attributes.rot_y;
+}
+
 void TrackManager::predict_tracks(uint frame_count, EKF& ekf)
 {
-  for(auto& track_pair : track_list_)
+  for (auto& track_pair : track_list_)
   {
     ekf.predict(frame_count, track_pair.second);
+    update_location(track_pair.first);
   }
 }
 
@@ -222,11 +217,13 @@ void TrackManager::update_track(uint id, const Measurement& meas, EKF& ekf)
   {
     track_list_.at(id).set_state(1);
   }
+  update_location(id);
+  update_attributes(id, meas);
 }
 
 void TrackManager::print()
 {
-  for(const auto& track_pair : track_list_)
+  for (const auto& track_pair : track_list_)
   {
     track_pair.second.print();
   }

--- a/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/Tracker.cpp
+++ b/3d_detection_and_tracking/modules/object_tracking/src/object_tracking/Tracker.cpp
@@ -144,6 +144,16 @@ const std::map<uint, Track>& TrackManager::get_track_list() const
   return track_list_;
 }
 
+std::map<uint, Attributes> TrackManager::get_attributes()
+{
+  std::map<uint, Attributes> ret;
+  for(const auto& track_pair : track_list_)
+  {
+    ret[track_pair.first] = track_pair.second.get_attributes();
+  }
+  return ret;
+}
+
 void TrackManager::manage_tracks(
   std::vector<uint> unassigned_track_ids,
   std::vector<uint> unassigned_meas_indexes,


### PR DESCRIPTION
처음에는 track_list_를 인자로 받아서 viewer로 출력하는 함수를 만들면 되지 않을까 생각했는데, 그러면 tracking / result_viewer 두개의 모듈이 서로 연결되어야 하는 문제가 있는 것 같네요.

그래서 track_manager 에서 attributes들의 map을(key = id, value = attributes) 리턴하는 메소드를 추가했습니다.
kitti_tracking.cpp 에 예시를 적어두었으니 이부분을 보고 사용하시면 될 것 같습니다.
다만 이렇게 될 경우 매번 attributes의 map을 생성해서 넘겨주기 때문에 약간 비효율적인 것 같기도 합니다.

